### PR TITLE
feat: Deserialize response fields

### DIFF
--- a/Typeform.Tests/AnswerDeserialization.cs
+++ b/Typeform.Tests/AnswerDeserialization.cs
@@ -8,7 +8,7 @@ public class AnswerDeserializationTests
 {
   private T GetAnswerFromFixture<T>(int answerIndex, int itemIndex = 0) where T : TypeformAnswer
   {
-    var responsesFixture = GetResponsesFixture();
+    var responsesFixture = FixturesHelper.GetResponsesFixture();
     var responses = JsonSerializer.Deserialize<TypeformResponsesContainer>(responsesFixture, TypeformClient.DefaultSystemTextJsonSerializerOptions);
 
     return responses!.Items[itemIndex].Answers.GetAnswer<T>(answerIndex);
@@ -118,10 +118,5 @@ public class AnswerDeserializationTests
     var answer = GetAnswerFromFixture<TypeformAnswer>(2);
 
     Assert.Equal(AnswerType.Unknown, answer.Type);
-  }
-
-  private string GetResponsesFixture()
-  {
-    return System.IO.File.ReadAllText("fixtures/responses.json");
   }
 }

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -64,4 +64,24 @@ public class ResponsesTests
     Assert.Equal(TypeformVariableType.Text, variable.Type);
     Assert.Equal("typeform", variable.Text);
   }
+
+  [Fact]
+  public void Deserializes_Response_Metadata()
+  {
+    var response = GetResponseFromFixture(0);
+    var expectedMetadata = new TypeformResponseMetadata()
+    {
+      Browser = "default",
+      NetworkId = "responsdent_network_id",
+      Platform = "other",
+      Referer = "https://user_id.typeform.com/to/lR6F4j",
+      UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
+    };
+
+    Assert.Equal(expectedMetadata.Browser, response.Metadata.Browser);
+    Assert.Equal(expectedMetadata.NetworkId, response.Metadata.NetworkId);
+    Assert.Equal(expectedMetadata.Platform, response.Metadata.Platform);
+    Assert.Equal(expectedMetadata.Referer, response.Metadata.Referer);
+    Assert.Equal(expectedMetadata.UserAgent, response.Metadata.UserAgent);
+  }
 }

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json;
+
+namespace Typeform.Tests;
+
+public class ResponsesTests
+{
+  [Fact]
+  public void Deserializes_Response_Top_Level_Fields()
+  {
+    var responsesFixture = FixturesHelper.GetResponsesFixture();
+    var responses = JsonSerializer.Deserialize<TypeformResponsesContainer>(responsesFixture, TypeformClient.DefaultSystemTextJsonSerializerOptions);
+
+    var expectedLandedAt = new DateTime(2017, 9, 14, 22, 33, 59, DateTimeKind.Utc);
+    Assert.Equal(expectedLandedAt, responses!.Items[0].LandedAt);
+  }
+}

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -5,13 +5,60 @@ namespace Typeform.Tests;
 
 public class ResponsesTests
 {
-  [Fact]
-  public void Deserializes_Response_Top_Level_Fields()
+  private TypeformResponse GetResponseFromFixture(int responseIndex)
   {
     var responsesFixture = FixturesHelper.GetResponsesFixture();
     var responses = JsonSerializer.Deserialize<TypeformResponsesContainer>(responsesFixture, TypeformClient.DefaultSystemTextJsonSerializerOptions);
 
+    return responses!.Items[responseIndex];
+  }
+
+  [Fact]
+  public void Deserializes_Response_LandedAt()
+  {
+    var response = GetResponseFromFixture(0);
     var expectedLandedAt = new DateTime(2017, 9, 14, 22, 33, 59, DateTimeKind.Utc);
-    Assert.Equal(expectedLandedAt, responses!.Items[0].LandedAt);
+    Assert.Equal(expectedLandedAt, response.LandedAt);
+  }
+
+  [Fact]
+  public void Deserializes_Response_LandingId()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal("21085286190ffad1248d17c4135ee56f", response.LandingId);
+  }
+
+  [Fact]
+  public void Deserializes_Response_ResponseId()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal("21085286190ffad1248d17c4135ee56f", response.ResponseId);
+  }
+
+  [Fact]
+  public void Deserializes_Response_Hidden()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal(true, response.Hidden.Value<bool>("bool"));
+    Assert.Equal("abc", response.Hidden.Value<string>("string"));
+    Assert.Equal(1, response.Hidden.Value<int>("number"));
+  }
+
+  [Fact]
+  public void Deserializes_Response_Variables_Number()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal("score", response.Variables[0].Key);
+    Assert.Equal("number", response.Variables[0].Type);
+    Assert.Equal(2, response.Variables[0].Number);
+  }
+
+  [Fact]
+  public void Deserializes_Response_Variables_Text()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal("name", response.Variables[0].Key);
+    Assert.Equal("text", response.Variables[0].Type);
+    Assert.Equal("typeform", response.Variables[0].Text);
   }
 }

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -36,6 +36,20 @@ public class ResponsesTests
   }
 
   [Fact]
+  public void Deserializes_Response_Token()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal("test21085286190ffad1248d17c4135ee56f", response.Token);
+  }
+
+  [Fact]
+  public void Deserializes_Response_Calculated()
+  {
+    var response = GetResponseFromFixture(0);
+    Assert.Equal(2, response.Calculated.Score);
+  }
+
+  [Fact]
   public void Deserializes_Response_Hidden()
   {
     var response = GetResponseFromFixture(0);

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -48,17 +48,20 @@ public class ResponsesTests
   public void Deserializes_Response_Variables_Number()
   {
     var response = GetResponseFromFixture(0);
-    Assert.Equal("score", response.Variables[0].Key);
-    Assert.Equal("number", response.Variables[0].Type);
-    Assert.Equal(2, response.Variables[0].Number);
+    var variable = response.Variables.GetVariable<TypeformVariableNumber>("score");
+    Assert.Equal("score", variable.Key);
+    Assert.Equal(TypeformVariableType.Number, variable.Type);
+    Assert.Equal(2, variable.Number);
   }
 
   [Fact]
   public void Deserializes_Response_Variables_Text()
   {
     var response = GetResponseFromFixture(0);
-    Assert.Equal("name", response.Variables[0].Key);
-    Assert.Equal("text", response.Variables[0].Type);
-    Assert.Equal("typeform", response.Variables[0].Text);
+    var variable = response.Variables.GetVariable<TypeformVariableText>("name");
+
+    Assert.Equal("name", variable.Key);
+    Assert.Equal(TypeformVariableType.Text, variable.Type);
+    Assert.Equal("typeform", variable.Text);
   }
 }

--- a/Typeform.Tests/fixtures/responses.json
+++ b/Typeform.Tests/fixtures/responses.json
@@ -171,7 +171,11 @@
       "calculated": {
         "score": 2
       },
-      "hidden": {},
+      "hidden": {
+        "bool": true,
+        "string": "abc",
+        "number": 1
+      },
       "landed_at": "2017-09-14T22:33:59Z",
       "landing_id": "21085286190ffad1248d17c4135ee56f",
       "metadata": {

--- a/Typeform.Tests/support/FixturesHelper.cs
+++ b/Typeform.Tests/support/FixturesHelper.cs
@@ -1,0 +1,8 @@
+namespace Typeform.Tests;
+
+public class FixturesHelper {
+  public static string GetResponsesFixture()
+  {
+    return System.IO.File.ReadAllText("fixtures/responses.json");
+  }
+}

--- a/Typeform/Client.cs
+++ b/Typeform/Client.cs
@@ -12,11 +12,16 @@ namespace Typeform
       PropertyNamingPolicy = new JsonSnakeCaseNamingPolicy(),
       Converters = {
         new TypeformAnswerJsonConverter(),
+        new TypeformVariableJsonConverter(),
         new JsonStringEnumMemberConverter(
           new JsonStringEnumMemberConverterOptions() {
             DeserializationFailureFallbackValue = AnswerType.Unknown
-          }, typeof(AnswerType))
-        }
+          }, typeof(AnswerType)),
+        new JsonStringEnumMemberConverter(
+          new JsonStringEnumMemberConverterOptions() {
+            DeserializationFailureFallbackValue = TypeformVariableType.Unknown
+          }, typeof(TypeformVariableType))
+        },
     };
 
     /// <summary>

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -68,7 +68,9 @@ public class TypeformResponse
   public TypeformResponse()
   {
     Answers = new AnswerList();
+    Variables = new TypeformVariablesList();
     Hidden = new TypeformDocumentData();
+    Metadata = new TypeformResponseMetadata();
   }
 
   public string ResponseId { get; set; }
@@ -84,6 +86,21 @@ public class TypeformResponse
   public AnswerList Answers { get; set; }
 
   public TypeformVariablesList Variables { get; set; }
+
+  public TypeformResponseMetadata Metadata { get; set; }
+}
+
+public class TypeformResponseMetadata
+{
+  public string Browser { get; set; }
+
+  public string NetworkId { get; set; }
+
+  public string Platform { get; set; }
+
+  public string Referer { get; set; }
+
+  public string UserAgent { get; set; }
 }
 
 public class TypeformDocumentData : Dictionary<string, JsonElement>

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -81,6 +82,8 @@ public class TypeformResponse
   public TypeformDocumentData Hidden { get; set; }
 
   public AnswerList Answers { get; set; }
+
+  public TypeformVariablesList Variables { get; set; }
 }
 
 public class TypeformDocumentData : Dictionary<string, JsonElement>
@@ -144,6 +147,19 @@ public class AnswerList : List<TypeformAnswer>
   }
 }
 
+public class TypeformVariablesList : List<TypeformVariable>
+{
+  public T GetVariable<T>(int index) where T : TypeformVariable
+  {
+    return (T)this[index];
+  }
+
+  public T GetVariable<T>(string key) where T : TypeformVariable
+  {
+    return (T)this.FirstOrDefault(v => v.Key == key);
+  }
+}
+
 public enum AnswerType
 {
   Unknown,
@@ -190,6 +206,32 @@ public enum QuestionType
   YesNo,
   [EnumMember(Value = "phone_number")]
   PhoneNumber
+}
+
+public enum TypeformVariableType
+{
+  Unknown,
+
+  Number,
+
+  Text,
+}
+
+public class TypeformVariable
+{
+  public string Key { get; set; }
+
+  public TypeformVariableType Type { get; set; }
+}
+
+public class TypeformVariableText : TypeformVariable
+{
+  public string Text { get; set; }
+}
+
+public class TypeformVariableNumber : TypeformVariable
+{
+  public int Number { get; set; }
 }
 
 public class TypeformAnswer

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -68,6 +68,8 @@ public class TypeformResponse
     Answers = new AnswerList();
   }
 
+  public DateTime LandedAt { get; set; }
+
   public AnswerList Answers { get; set; }
 }
 
@@ -197,12 +199,14 @@ public class TypeformDateAnswer : TypeformAnswer
   public DateTime Date { get; set; }
 }
 
-public class TypeformPaymentAnswer : TypeformAnswer {
+public class TypeformPaymentAnswer : TypeformAnswer
+{
 
   public TypeformPaymentAnswerData Payment { get; set; }
 }
 
-public class TypeformPaymentAnswerData {
+public class TypeformPaymentAnswerData
+{
   public string Amount { get; set; }
 
   public string Last4 { get; set; }

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -74,12 +74,24 @@ public class TypeformResponse
     Calculated = new TypeformResponseCalculatedFields();
   }
 
+  /// <summary>
+  /// Unique ID for the response. Note that `response_id` values are unique per form but are not unique globally.
+  /// </summary>
+  /// <value></value>
   public string ResponseId { get; set; }
 
   public string LandingId { get; set; }
 
+  /// <summary>
+  /// Time of the form landing. In ISO 8601 format, UTC time, to the second, with T as a delimiter between the date and time
+  /// </summary>
+  /// <value></value>
   public DateTime LandedAt { get; set; }
 
+  /// <summary>
+  /// Time that the form response was submitted. In ISO 8601 format, UTC time, to the second, with T as a delimiter between the date and time.
+  /// </summary>
+  /// <value></value>
   public DateTime SubmittedAt { get; set; }
 
   public string Token { get; set; }
@@ -92,6 +104,10 @@ public class TypeformResponse
 
   public TypeformVariablesList Variables { get; set; }
 
+  /// <summary>
+  /// Metadata about a client's HTTP request.
+  /// </summary>
+  /// <value></value>
   public TypeformResponseMetadata Metadata { get; set; }
 }
 
@@ -104,8 +120,16 @@ public class TypeformResponseMetadata
 {
   public string Browser { get; set; }
 
+  /// <summary>
+  /// IP of the client
+  /// </summary>
+  /// <value></value>
   public string NetworkId { get; set; }
 
+  /// <summary>
+  /// Derived from user agent
+  /// </summary>
+  /// <value></value>
   public string Platform { get; set; }
 
   public string Referer { get; set; }

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Refit;
@@ -66,11 +67,73 @@ public class TypeformResponse
   public TypeformResponse()
   {
     Answers = new AnswerList();
+    Hidden = new TypeformDocumentData();
   }
+
+  public string ResponseId { get; set; }
+
+  public string LandingId { get; set; }
 
   public DateTime LandedAt { get; set; }
 
+  public DateTime SubmittedAt { get; set; }
+
+  public TypeformDocumentData Hidden { get; set; }
+
   public AnswerList Answers { get; set; }
+}
+
+public class TypeformDocumentData : Dictionary<string, JsonElement>
+{
+  public T Value<T>(string key)
+  {
+    if (typeof(T).IsAssignableFrom(typeof(String)))
+    {
+      return (T)(object)this[key].GetString();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Boolean)))
+    {
+      return (T)(object)this[key].GetBoolean();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Int32)))
+    {
+      return (T)(object)this[key].GetInt32();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Int16)))
+    {
+      return (T)(object)this[key].GetInt16();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Int64)))
+    {
+      return (T)(object)this[key].GetInt64();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(DateTime)))
+    {
+      return (T)(object)this[key].GetDateTime();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(DateTimeOffset)))
+    {
+      return (T)(object)this[key].GetDateTimeOffset();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Guid)))
+    {
+      return (T)(object)this[key].GetGuid();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(SByte)))
+    {
+      return (T)(object)this[key].GetSByte();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Single)))
+    {
+      return (T)(object)this[key].GetSingle();
+    }
+    else if (typeof(T).IsAssignableFrom(typeof(Decimal)))
+    {
+      return (T)(object)this[key].GetDecimal();
+    }
+
+    throw new InvalidOperationException($"Unsupported type {typeof(T)} to deserialize from JSON");
+  }
 }
 
 public class AnswerList : List<TypeformAnswer>

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -71,6 +71,7 @@ public class TypeformResponse
     Variables = new TypeformVariablesList();
     Hidden = new TypeformDocumentData();
     Metadata = new TypeformResponseMetadata();
+    Calculated = new TypeformResponseCalculatedFields();
   }
 
   public string ResponseId { get; set; }
@@ -81,6 +82,10 @@ public class TypeformResponse
 
   public DateTime SubmittedAt { get; set; }
 
+  public string Token { get; set; }
+
+  public TypeformResponseCalculatedFields Calculated { get; set; }
+
   public TypeformDocumentData Hidden { get; set; }
 
   public AnswerList Answers { get; set; }
@@ -88,6 +93,11 @@ public class TypeformResponse
   public TypeformVariablesList Variables { get; set; }
 
   public TypeformResponseMetadata Metadata { get; set; }
+}
+
+public class TypeformResponseCalculatedFields
+{
+  public int? Score { get; set; }
 }
 
 public class TypeformResponseMetadata
@@ -248,7 +258,7 @@ public class TypeformVariableText : TypeformVariable
 
 public class TypeformVariableNumber : TypeformVariable
 {
-  public int Number { get; set; }
+  public int? Number { get; set; }
 }
 
 public class TypeformAnswer
@@ -285,7 +295,7 @@ public class TypeformUrlAnswer : TypeformAnswer
 
 public class TypeformNumberAnswer : TypeformAnswer
 {
-  public int Number { get; set; }
+  public int? Number { get; set; }
 }
 
 public class TypeformChoicesAnswer : TypeformAnswer
@@ -318,7 +328,7 @@ public class TypeformChoiceLabel
 
 public class TypeformDateAnswer : TypeformAnswer
 {
-  public DateTime Date { get; set; }
+  public DateTime? Date { get; set; }
 }
 
 public class TypeformPaymentAnswer : TypeformAnswer

--- a/Typeform/TypeformVariableJsonConverter.cs
+++ b/Typeform/TypeformVariableJsonConverter.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Typeform
+{
+
+  public class TypeformVariableJsonConverter : JsonConverter<TypeformVariable>
+  {
+
+    public override bool CanConvert(Type typeToConvert) =>
+            typeof(TypeformVariable).IsAssignableFrom(typeToConvert);
+
+    public override TypeformVariable Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      if (reader.TokenType != JsonTokenType.StartObject)
+      {
+        throw new JsonException();
+      }
+
+      using (var jsonDocument = JsonDocument.ParseValue(ref reader))
+      {
+        var typePropertyName = options.PropertyNamingPolicy.ConvertName(nameof(TypeformVariable.Type));
+        if (!jsonDocument.RootElement.TryGetProperty(typePropertyName, out var typeProperty))
+        {
+          throw new JsonException();
+        }
+
+        TypeformVariableType type = TypeformVariableType.Unknown;
+        string rawJson = jsonDocument.RootElement.GetRawText();
+        var modifiedOptions = new JsonSerializerOptions(options);
+        var existingConverter = modifiedOptions.Converters.FirstOrDefault(c => c is TypeformVariableJsonConverter);
+        if (existingConverter != null)
+        {
+          modifiedOptions.Converters.Remove(existingConverter);
+        }
+
+        // TODO: This could be optimized maybe to avoid deserializing entire object?
+        // { type: "text" }
+        var typePropertyJson = $"{{ \"type\": \"{typeProperty.GetString()}\" }}";
+        var defaultVariable = JsonSerializer.Deserialize<TypeformVariable>(typePropertyJson, modifiedOptions);
+
+        type = defaultVariable.Type;
+
+        Type variableInstanceType;
+
+        switch (type)
+        {
+          case TypeformVariableType.Text:
+            variableInstanceType = typeof(TypeformVariableText);
+            break;
+          case TypeformVariableType.Number:
+            variableInstanceType = typeof(TypeformVariableNumber);
+            break;          
+          default:
+            return defaultVariable;
+        }
+
+        var result = (TypeformVariable)JsonSerializer.Deserialize(
+          rawJson, variableInstanceType, modifiedOptions);
+
+        return result;
+      }
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer, TypeformVariable variable, JsonSerializerOptions options)
+    {
+      JsonSerializer.Serialize(writer, (object)variable, options);
+    }
+  }
+}


### PR DESCRIPTION
## TODOs

- [x] Add support for the rest of the response fields

## Notes

- Do we need to add `definitions`? I don't see it in the official docs.

```
definition?: {
      fields?: {
        id?: string
        type?: string
        title?: string
        description?: string
      }[]
    }
```

## Resources

- https://github.com/Typeform/js-api-client/blob/master/src/typeform-types.ts
