### PR TITLE
refactor: enable C# 10

### DIFF
--- a/Typeform.Tests/AnswerDeserialization.cs
+++ b/Typeform.Tests/AnswerDeserialization.cs
@@ -72,6 +72,7 @@ public class AnswerDeserializationTests
     Assert.Equal(expectedDate, answer.Date);
   }
 
+  [Fact]
   public void Deserializes_Answer_Choice_Field()
   {
     var answer = GetAnswerFromFixture<TypeformChoiceAnswer>(12);
@@ -81,6 +82,7 @@ public class AnswerDeserializationTests
     Assert.Equal("A friend's experience in Sydney", answer.Choice.Label);
   }
 
+  [Fact]
   public void Deserializes_Answer_FileUrl_Field()
   {
     var answer = GetAnswerFromFixture<TypeformFileUrlAnswer>(1, itemIndex: 1);
@@ -90,6 +92,7 @@ public class AnswerDeserializationTests
     Assert.Equal(expectedUri, answer.FileUrl);
   }
 
+  [Fact]
   public void Deserializes_Answer_Url_Field()
   {
     var answer = GetAnswerFromFixture<TypeformUrlAnswer>(15);
@@ -99,17 +102,21 @@ public class AnswerDeserializationTests
     Assert.Equal(expectedUri, answer.Url);
   }
 
+  [Fact]
   public void Deserializes_Answer_Payment_Field()
   {
     var answer = GetAnswerFromFixture<TypeformPaymentAnswer>(16);
-
-    Assert.Equal(AnswerType.Payment, answer.Type);
-    Assert.Equal(new TypeformPaymentAnswerData()
+    var expectedPaymentData = new TypeformPaymentAnswerData()
     {
       Amount = "$1.00",
       Name = "Franz Tester",
       Last4 = "1234"
-    }, answer.Payment);
+    };
+
+    Assert.Equal(AnswerType.Payment, answer.Type);
+    Assert.Equal(expectedPaymentData.Amount, answer.Payment.Amount);
+    Assert.Equal(expectedPaymentData.Name, answer.Payment.Name);
+    Assert.Equal(expectedPaymentData.Last4, answer.Payment.Last4);
   }
 
   [Fact]

--- a/Typeform.Tests/Responses.cs
+++ b/Typeform.Tests/Responses.cs
@@ -53,7 +53,7 @@ public class ResponsesTests
   public void Deserializes_Response_Hidden()
   {
     var response = GetResponseFromFixture(0);
-    Assert.Equal(true, response.Hidden.Value<bool>("bool"));
+    Assert.True(response.Hidden.Value<bool>("bool"));
     Assert.Equal("abc", response.Hidden.Value<string>("string"));
     Assert.Equal(1, response.Hidden.Value<int>("number"));
   }

--- a/Typeform/Client.cs
+++ b/Typeform/Client.cs
@@ -1,9 +1,6 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
-using Refit;
 
-namespace Typeform
-{
+namespace Typeform;
 
   public class TypeformClient
   {
@@ -60,4 +57,3 @@ namespace Typeform
       return typeformApi;
     }
   }
-}

--- a/Typeform/GlobalUsings.cs
+++ b/Typeform/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using System.Text;
+global using System.Text.Json;
+global using Refit;

--- a/Typeform/JsonSnakeCaseNamingPolicy.cs
+++ b/Typeform/JsonSnakeCaseNamingPolicy.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Text;
-using System.Text.Json;
+namespace Typeform;
 
 public class JsonSnakeCaseNamingPolicy : JsonNamingPolicy
 {

--- a/Typeform/Typeform.csproj
+++ b/Typeform/Typeform.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
     <NuspecProperties>version=$(Version)</NuspecProperties>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Typeform/TypeformAnswerJsonConverter.cs
+++ b/Typeform/TypeformAnswerJsonConverter.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Linq;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Typeform
-{
+namespace Typeform;
 
   public class TypeformAnswerJsonConverter : JsonConverter<TypeformAnswer>
   {
@@ -95,4 +91,3 @@ namespace Typeform
       JsonSerializer.Serialize(writer, (object)answer, options);
     }
   }
-}

--- a/Typeform/TypeformApi.cs
+++ b/Typeform/TypeformApi.cs
@@ -1,39 +1,30 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using Refit;
 
-namespace Typeform
+namespace Typeform;
+
+public interface ITypeformApi
 {
+  /// <summary>
+  /// Typeform Responses API
+  /// </summary>
+  /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
+  /// <returns></returns>
+  [Get("/forms/{form_id}/responses")]
+  Task<TypeformResponsesContainer> GetFormResponsesAsync(
+    [Authorize("Bearer")] string accessToken,
+    [AliasAs("form_id")] string formId);
 
-  public interface ITypeformApi
-  {
-    /// <summary>
-    /// Typeform Responses API
-    /// </summary>
-    /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
-    /// <returns></returns>
-    [Get("/forms/{form_id}/responses")]
-    Task<TypeformResponsesContainer> GetFormResponsesAsync(
-      [Authorize("Bearer")] string accessToken,
-      [AliasAs("form_id")] string formId);
-
-    /// <summary>
-    /// Typeform Responses API
-    /// </summary>
-    /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
-    /// <param name="queryParams">Optional query parameters to pass to Responses endpoint</param>
-    /// <returns></returns>
-    [Get("/forms/{form_id}/responses")]
-    Task<TypeformResponsesContainer> GetFormResponsesAsync(
-      [Authorize("Bearer")] string accessToken,
-      [AliasAs("form_id")] string formId,
-      TypeformResponsesParameters queryParams);
-  }
+  /// <summary>
+  /// Typeform Responses API
+  /// </summary>
+  /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
+  /// <param name="queryParams">Optional query parameters to pass to Responses endpoint</param>
+  /// <returns></returns>
+  [Get("/forms/{form_id}/responses")]
+  Task<TypeformResponsesContainer> GetFormResponsesAsync(
+    [Authorize("Bearer")] string accessToken,
+    [AliasAs("form_id")] string formId,
+    TypeformResponsesParameters queryParams);
 }
 
 public class TypeformResponsesContainer

--- a/Typeform/TypeformVariableJsonConverter.cs
+++ b/Typeform/TypeformVariableJsonConverter.cs
@@ -1,74 +1,70 @@
-using System;
-using System.Linq;
-using System.Text.Json;
+
 using System.Text.Json.Serialization;
 
-namespace Typeform
+namespace Typeform;
+
+public class TypeformVariableJsonConverter : JsonConverter<TypeformVariable>
 {
 
-  public class TypeformVariableJsonConverter : JsonConverter<TypeformVariable>
+  public override bool CanConvert(Type typeToConvert) =>
+          typeof(TypeformVariable).IsAssignableFrom(typeToConvert);
+
+  public override TypeformVariable Read(
+      ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
   {
-
-    public override bool CanConvert(Type typeToConvert) =>
-            typeof(TypeformVariable).IsAssignableFrom(typeToConvert);
-
-    public override TypeformVariable Read(
-        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    if (reader.TokenType != JsonTokenType.StartObject)
     {
-      if (reader.TokenType != JsonTokenType.StartObject)
+      throw new JsonException();
+    }
+
+    using (var jsonDocument = JsonDocument.ParseValue(ref reader))
+    {
+      var typePropertyName = options.PropertyNamingPolicy.ConvertName(nameof(TypeformVariable.Type));
+      if (!jsonDocument.RootElement.TryGetProperty(typePropertyName, out var typeProperty))
       {
         throw new JsonException();
       }
 
-      using (var jsonDocument = JsonDocument.ParseValue(ref reader))
+      TypeformVariableType type = TypeformVariableType.Unknown;
+      string rawJson = jsonDocument.RootElement.GetRawText();
+      var modifiedOptions = new JsonSerializerOptions(options);
+      var existingConverter = modifiedOptions.Converters.FirstOrDefault(c => c is TypeformVariableJsonConverter);
+      if (existingConverter != null)
       {
-        var typePropertyName = options.PropertyNamingPolicy.ConvertName(nameof(TypeformVariable.Type));
-        if (!jsonDocument.RootElement.TryGetProperty(typePropertyName, out var typeProperty))
-        {
-          throw new JsonException();
-        }
-
-        TypeformVariableType type = TypeformVariableType.Unknown;
-        string rawJson = jsonDocument.RootElement.GetRawText();
-        var modifiedOptions = new JsonSerializerOptions(options);
-        var existingConverter = modifiedOptions.Converters.FirstOrDefault(c => c is TypeformVariableJsonConverter);
-        if (existingConverter != null)
-        {
-          modifiedOptions.Converters.Remove(existingConverter);
-        }
-
-        // TODO: This could be optimized maybe to avoid deserializing entire object?
-        // { type: "text" }
-        var typePropertyJson = $"{{ \"type\": \"{typeProperty.GetString()}\" }}";
-        var defaultVariable = JsonSerializer.Deserialize<TypeformVariable>(typePropertyJson, modifiedOptions);
-
-        type = defaultVariable.Type;
-
-        Type variableInstanceType;
-
-        switch (type)
-        {
-          case TypeformVariableType.Text:
-            variableInstanceType = typeof(TypeformVariableText);
-            break;
-          case TypeformVariableType.Number:
-            variableInstanceType = typeof(TypeformVariableNumber);
-            break;          
-          default:
-            return defaultVariable;
-        }
-
-        var result = (TypeformVariable)JsonSerializer.Deserialize(
-          rawJson, variableInstanceType, modifiedOptions);
-
-        return result;
+        modifiedOptions.Converters.Remove(existingConverter);
       }
-    }
 
-    public override void Write(
-        Utf8JsonWriter writer, TypeformVariable variable, JsonSerializerOptions options)
-    {
-      JsonSerializer.Serialize(writer, (object)variable, options);
+      // TODO: This could be optimized maybe to avoid deserializing entire object?
+      // { type: "text" }
+      var typePropertyJson = $"{{ \"type\": \"{typeProperty.GetString()}\" }}";
+      var defaultVariable = JsonSerializer.Deserialize<TypeformVariable>(typePropertyJson, modifiedOptions);
+
+      type = defaultVariable.Type;
+
+      Type variableInstanceType;
+
+      switch (type)
+      {
+        case TypeformVariableType.Text:
+          variableInstanceType = typeof(TypeformVariableText);
+          break;
+        case TypeformVariableType.Number:
+          variableInstanceType = typeof(TypeformVariableNumber);
+          break;
+        default:
+          return defaultVariable;
+      }
+
+      var result = (TypeformVariable)JsonSerializer.Deserialize(
+        rawJson, variableInstanceType, modifiedOptions);
+
+      return result;
     }
+  }
+
+  public override void Write(
+      Utf8JsonWriter writer, TypeformVariable variable, JsonSerializerOptions options)
+  {
+    JsonSerializer.Serialize(writer, (object)variable, options);
   }
 }


### PR DESCRIPTION
## Changes

- Enable C# 10.0 using `<LangVersion>` project attribute
- Add back implicit and global usings
- Switch to pattern matching (and clean up code) for Json Converters
- fix: tests missing `[Fact]` attribute

## Resources

- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version