### PR TITLE
feat: Support deleting responses and retrieving files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A .NET Standard 2.0 SDK wrapper built with [Refit](https://github.com/reactiveui
 ## Supported Endpoints
 
 - [Retrieve responses](https://developer.typeform.com/responses/reference/retrieve-responses/)
+- [Retrieve response file](https://developer.typeform.com/responses/reference/retrieve-response-file/)
 - [Delete responses](https://developer.typeform.com/responses/reference/delete-responses/)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A .NET Standard 2.0 SDK wrapper built with [Refit](https://github.com/reactiveui
 
 ## Supported Endpoints
 
-- [Retrieve Responses](https://developer.typeform.com/responses/reference/retrieve-responses/) (https://api.typeform.com/forms/{form_id}/responses)
+- [Retrieve responses](https://developer.typeform.com/responses/reference/retrieve-responses/)
+- [Delete responses](https://developer.typeform.com/responses/reference/delete-responses/)
 
 ## Usage
 
@@ -167,7 +168,7 @@ var answerText = responses.Items[0].Variables.GetVariable<TypeformVariableText>(
 - [x] Target .NET Standard / maximize compatibility
 - [ ] Support for [Responses API](https://developer.typeform.com/responses/)
   - [x] [Retrieve responses](https://developer.typeform.com/responses/reference/retrieve-responses/)
-  - [ ] [Delete responses](https://developer.typeform.com/responses/reference/delete-responses/)
+  - [x] [Delete responses](https://developer.typeform.com/responses/reference/delete-responses/)
   - [ ] [Retrieve response file](https://developer.typeform.com/responses/reference/retrieve-response-file/)
   - [ ] [Retrieve Form Insights](https://developer.typeform.com/responses/reference/retrieve-form-insights/)
 - [ ] Support for [Webhooks API](https://developer.typeform.com/webhooks/)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ public class HomeController : Controller {
 }
 ```
 
-## Responses API
+# Responses API
+
+## Retrieve Responses
 
 The Typeform Responses API returns form responses that include answers. Each answer can be a different type and to accomodate this, the SDK deserializes into different class implementations based on the answer `type` discriminator.
 
@@ -165,6 +167,37 @@ var responses = await _typeformApi.GetFormResponsesAsync(accessToken, formId);
 // Retrieve first response's variable (by key)
 var answerText = responses.Items[0].Variables.GetVariable<TypeformVariableText>("name");
 ```
+
+## Delete Responses
+
+Use `ITypeformApi.DeleteResponsesAsync()` and pass a list of response IDs to delete.
+
+## Retrieve Response File
+
+Uploaded files to a form can be downloaded via the REST API, however, you **cannot** rely on the values of `file_url`
+in Form Responses. Instead, you can manually specify the `form_id`, `response_id`, `field_id` and `filename` to download
+using `ITypeformApi.GetFormResponseFileStreamAsync()`.
+
+The return value of this method is a Refit `ApiResponse<Stream>` and you can manipulate the `Stream` response any way
+you see fit. There is a `ReadAllBytesAsync()` extension method that will read the full bytes using a chunked buffer:
+
+```c#
+ITypeformApi typeformApi = TypeformClient.CreateApi();
+
+ApiResponse<Stream> fileResponse = await typeformApi.GetFormResponseFileStreamAsync(
+  accessToken,
+  formId,
+  responseId,
+  fieldId,
+  filename
+);
+
+var contents = await fileResponse.ReadAllBytesAsync(/* chunkSize: <optional value in bytes> */);
+
+await System.IO.File.WriteAllBytesAsync(filename, contents);
+```
+
+If you need to download a file using a `FileUrl` value from the Form Responses API, you will need to construct your own `HttpClient` to download it [like this example](https://dev.to/1001binary/download-file-using-httpclient-wrapper-asynchronously-1p6).
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ var answerText = responses.Items[0].Variables.GetVariable<TypeformVariableText>(
 - [ ] Support for [Responses API](https://developer.typeform.com/responses/)
   - [x] [Retrieve responses](https://developer.typeform.com/responses/reference/retrieve-responses/)
   - [x] [Delete responses](https://developer.typeform.com/responses/reference/delete-responses/)
-  - [ ] [Retrieve response file](https://developer.typeform.com/responses/reference/retrieve-response-file/)
+  - [x] [Retrieve response file](https://developer.typeform.com/responses/reference/retrieve-response-file/)
   - [ ] [Retrieve Form Insights](https://developer.typeform.com/responses/reference/retrieve-form-insights/)
 - [ ] Support for [Webhooks API](https://developer.typeform.com/webhooks/)
 - [ ] Support for [Create API](https://developer.typeform.com/create/)

--- a/Typeform.Tests/Integration.cs
+++ b/Typeform.Tests/Integration.cs
@@ -53,7 +53,28 @@ public class IntegrationTests
 
     var contents = await fileResponse.ReadAllBytesAsync();
     Assert.NotNull(contents);
-    Assert.Equal(1_699_840, contents.Length);
+    Assert.Equal(1_692_347, contents.Length);
+
+    // write to file system
+    // await System.IO.File.WriteAllBytesAsync("test.zip", contents);
+  }
+
+  [Fact]
+  public async Task Client_Can_Download_File_Using_File_Url_From_Responses_Api()
+  {
+    var accessToken = Configuration["TypeformAccessToken"];
+
+    // TODO: This file_url is available in the response
+    // and it would be nice to figure out how to pass
+    // that in and get the downloaded file
+    var fileResponse = await _api.GetFormResponseFileStreamFromUrlAsync(
+      accessToken,
+      new System.Uri("https://api.typeform.com/forms/Mj5yRSHu/responses/8kvscilox7xp42d58c8kvsc39l6ct2rg/fields/a6MMDcSis1p1/files/c001c8c70d77-derwinternaht.zip")
+    );
+
+    var contents = await fileResponse.ReadAllBytesAsync();
+    Assert.NotNull(contents);
+    Assert.Equal(1_692_347, contents.Length);
 
     // write to file system
     // await System.IO.File.WriteAllBytesAsync("test.zip", contents);

--- a/Typeform.Tests/Integration.cs
+++ b/Typeform.Tests/Integration.cs
@@ -43,7 +43,7 @@ public class IntegrationTests
     // TODO: This file_url is available in the response
     // and it would be nice to figure out how to pass
     // that in and get the downloaded file
-    var fileStream = await _api.GetFormResponseFile(
+    var fileStream = await _api.GetFormResponseFileStreamAsync(
       accessToken,
       "Mj5yRSHu",
       "8kvscilox7xp42d58c8kvsc39l6ct2rg",

--- a/Typeform.Tests/Integration.cs
+++ b/Typeform.Tests/Integration.cs
@@ -43,7 +43,7 @@ public class IntegrationTests
     // TODO: This file_url is available in the response
     // and it would be nice to figure out how to pass
     // that in and get the downloaded file
-    var fileStream = await _api.GetFormResponseFileStreamAsync(
+    var fileResponse = await _api.GetFormResponseFileStreamAsync(
       accessToken,
       "Mj5yRSHu",
       "8kvscilox7xp42d58c8kvsc39l6ct2rg",
@@ -51,7 +51,7 @@ public class IntegrationTests
       "c001c8c70d77-derwinternaht.zip"
     );
 
-    var contents = await TypeformClient.ReadChunkedStreamAsync(fileStream);
+    var contents = await fileResponse.ReadAllBytesAsync();
     Assert.NotNull(contents);
     Assert.Equal(1_699_840, contents.Length);
 

--- a/Typeform.Tests/Integration.cs
+++ b/Typeform.Tests/Integration.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace Typeform.Tests;
@@ -31,5 +33,29 @@ public class IntegrationTests
       "xVMHX23n");
 
     Assert.True(responses.TotalItems > 0);
+  }
+
+  [Fact]
+  public async Task Client_Can_Download_File_From_Responses_Api()
+  {
+    var accessToken = Configuration["TypeformAccessToken"];
+
+    // TODO: This file_url is available in the response
+    // and it would be nice to figure out how to pass
+    // that in and get the downloaded file
+    var fileStream = await _api.GetFormResponseFile(
+      accessToken,
+      "Mj5yRSHu",
+      "8kvscilox7xp42d58c8kvsc39l6ct2rg",
+      "a6MMDcSis1p1",
+      "c001c8c70d77-derwinternaht.zip"
+    );
+
+    var contents = await TypeformClient.ReadChunkedStreamAsync(fileStream);
+    Assert.NotNull(contents);
+    Assert.Equal(1_699_840, contents.Length);
+
+    // write to file system
+    // await System.IO.File.WriteAllBytesAsync("test.zip", contents);
   }
 }

--- a/Typeform/Api.cs
+++ b/Typeform/Api.cs
@@ -44,7 +44,7 @@ public interface ITypeformApi
   /// </summary>
   /// <param name="includedResponseIds">List of response_id values of the responses to delete. You can list up to 1000 tokens.</param>
   [Get("/forms/{formId}/responses/{responseId}/fields/{fieldId}/files/{filename}")]
-  Task<Stream> GetFormResponseFile(
+  Task<Stream> GetFormResponseFileStreamAsync(
     [Authorize("Bearer")] string accessToken,
     string formId,
     string responseId,

--- a/Typeform/Api.cs
+++ b/Typeform/Api.cs
@@ -27,10 +27,20 @@ public interface ITypeformApi
   Task<TypeformResponseItems> GetFormResponsesAsync(
     [Authorize("Bearer")] string accessToken,
     [AliasAs("form_id")] string formId,
-    TypeformResponsesParameters queryParams);
+    TypeformGetResponsesParameters queryParams);
+
+  /// <summary>
+  /// Delete responses to a form.
+  /// </summary>
+  /// <param name="includedResponseIds">List of response_id values of the responses to delete. You can list up to 1000 tokens.</param>
+  [Delete("/forms/{form_id}/responses")]
+  Task<TypeformResponseItems> DeleteFormResponsesAsync(
+    [Authorize("Bearer")] string accessToken,
+    [AliasAs("form_id")] string formId,
+    [AliasAs("included_response_ids")] string[] includedResponseIds);
 }
 
-public class TypeformResponsesParameters
+public class TypeformGetResponsesParameters
 {
   /// <summary>
   /// Maximum number of responses. Default value is 25. Maximum value is 1000. 
@@ -120,7 +130,7 @@ public class TypeformResponsesParameters
   /// comma-separated list to specify more than one field value.
   /// </summary>
   /// <value></value>
-  public string Fields { get; set; }
+  public string[] Fields { get; set; }
 
   /// <summary>
   /// Limit request to only responses that include the specified fields in 
@@ -128,5 +138,5 @@ public class TypeformResponsesParameters
   /// one field value - response will contain at least one of the specified fields.
   /// </summary>
   /// <value></value>
-  public string AnsweredFields { get; set; }
+  public string[] AnsweredFields { get; set; }
 }

--- a/Typeform/Api.cs
+++ b/Typeform/Api.cs
@@ -11,10 +11,10 @@ public interface ITypeformApi
   /// <param name="accessToken">The OAuth or Personal Access Token to authorize the call</param>
   /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
   /// <returns></returns>
-  [Get("/forms/{form_id}/responses")]
+  [Get("/forms/{formId}/responses")]
   Task<TypeformResponseItems> GetFormResponsesAsync(
     [Authorize("Bearer")] string accessToken,
-    [AliasAs("form_id")] string formId);
+    string formId);
 
   /// <summary>
   /// Typeform Responses API
@@ -23,21 +23,34 @@ public interface ITypeformApi
   /// <param name="formId">Unique ID for the form. Find in your form URL. For example, in the URL "https://mysite.typeform.com/to/u6nXL7" the form_id is u6nXL7.</param>
   /// <param name="queryParams">Optional query parameters to pass to Responses endpoint</param>
   /// <returns></returns>
-  [Get("/forms/{form_id}/responses")]
+  [Get("/forms/{formId}/responses")]
   Task<TypeformResponseItems> GetFormResponsesAsync(
     [Authorize("Bearer")] string accessToken,
-    [AliasAs("form_id")] string formId,
+    string formId,
     TypeformGetResponsesParameters queryParams);
 
   /// <summary>
   /// Delete responses to a form.
   /// </summary>
   /// <param name="includedResponseIds">List of response_id values of the responses to delete. You can list up to 1000 tokens.</param>
-  [Delete("/forms/{form_id}/responses")]
+  [Delete("/forms/{formId}/responses")]
   Task<TypeformResponseItems> DeleteFormResponsesAsync(
     [Authorize("Bearer")] string accessToken,
-    [AliasAs("form_id")] string formId,
+    string formId,
     [AliasAs("included_response_ids")] string[] includedResponseIds);
+
+  /// <summary>
+  /// Delete responses to a form.
+  /// </summary>
+  /// <param name="includedResponseIds">List of response_id values of the responses to delete. You can list up to 1000 tokens.</param>
+  [Get("/forms/{formId}/responses/{responseId}/fields/{fieldId}/files/{filename}")]
+  Task<Stream> GetFormResponseFile(
+    [Authorize("Bearer")] string accessToken,
+    string formId,
+    string responseId,
+    string fieldId,
+    string filename,
+    bool inline = false);
 }
 
 public class TypeformGetResponsesParameters

--- a/Typeform/Client.cs
+++ b/Typeform/Client.cs
@@ -67,4 +67,44 @@ public class TypeformClient
 
     return typeformApi;
   }
+
+  private static async Task<(int readCount, byte[] buffer)> ReadChunkAsync(Stream stream, int chunkSize)
+  {
+    var buffer = new byte[chunkSize];
+    var readCount = 0;
+
+    while (readCount < chunkSize)
+    {
+      var bytesRead = await stream.ReadAsync(buffer, readCount, chunkSize - readCount);
+
+      if (bytesRead == 0)
+      {
+        break;
+      }
+
+      readCount += bytesRead;
+    }
+
+    return (readCount, buffer);
+  }
+
+  /// <summary>
+  /// TODO: Move?
+  /// </summary>
+  /// <param name="stream"></param>
+  /// <returns></returns>
+  public static async Task<byte[]> ReadChunkedStreamAsync(Stream stream)
+  {
+    IEnumerable<byte> contents = new byte[0];
+    int lastRead;
+
+    do
+    {
+      var (readCount, buffer) = await TypeformClient.ReadChunkAsync(stream, 4096);
+      lastRead = readCount;
+      contents = contents.Concat(buffer);
+    } while (lastRead > 0);
+
+    return contents.ToArray();
+  }
 }

--- a/Typeform/Client.cs
+++ b/Typeform/Client.cs
@@ -37,6 +37,7 @@ public class TypeformClient
   /// <value></value>
   public static RefitSettings DefaultSettings => new RefitSettings
   {
+    CollectionFormat = CollectionFormat.Csv,
     ContentSerializer = new SystemTextJsonContentSerializer(DefaultSystemTextJsonSerializerOptions)
   };
 

--- a/Typeform/Client.cs
+++ b/Typeform/Client.cs
@@ -68,43 +68,5 @@ public class TypeformClient
     return typeformApi;
   }
 
-  private static async Task<(int readCount, byte[] buffer)> ReadChunkAsync(Stream stream, int chunkSize)
-  {
-    var buffer = new byte[chunkSize];
-    var readCount = 0;
-
-    while (readCount < chunkSize)
-    {
-      var bytesRead = await stream.ReadAsync(buffer, readCount, chunkSize - readCount);
-
-      if (bytesRead == 0)
-      {
-        break;
-      }
-
-      readCount += bytesRead;
-    }
-
-    return (readCount, buffer);
-  }
-
-  /// <summary>
-  /// TODO: Move?
-  /// </summary>
-  /// <param name="stream"></param>
-  /// <returns></returns>
-  public static async Task<byte[]> ReadChunkedStreamAsync(Stream stream)
-  {
-    IEnumerable<byte> contents = new byte[0];
-    int lastRead;
-
-    do
-    {
-      var (readCount, buffer) = await TypeformClient.ReadChunkAsync(stream, 4096);
-      lastRead = readCount;
-      contents = contents.Concat(buffer);
-    } while (lastRead > 0);
-
-    return contents.ToArray();
-  }
+  
 }


### PR DESCRIPTION
## Changes

- Add support for deleting responses
- Add `GetFormResponseFileStreamAsync`
- Add extension method `ReadAllBytesAsync` to get all bytes for a file response
- Add extension method `GetFormResponseFileStreamFromUrlAsync` to get file by URL value

## Resources

- https://stackoverflow.com/questions/415291/best-way-to-combine-two-or-more-byte-arrays-in-c-sharp
- https://stackoverflow.com/questions/65842011/how-to-read-chunkedencodingreadstream-in-net-core
- https://stackoverflow.com/questions/1080442/how-to-convert-an-stream-into-a-byte-in-c